### PR TITLE
fix: info path redaction + memory query pagination (review 12, 13)

### DIFF
--- a/src/db/ladybug-memory.ts
+++ b/src/db/ladybug-memory.ts
@@ -152,11 +152,14 @@ export async function queryMemories(
     symbolIds?: string[];
     staleOnly?: boolean;
     limit?: number;
+    offset?: number;
     sortBy?: "recency" | "confidence";
   },
 ): Promise<MemoryRow[]> {
   const safeLimit = options.limit ?? 10;
+  const safeOffset = options.offset ?? 0;
   assertSafeInt(safeLimit, "limit");
+  assertSafeInt(safeOffset, "offset");
 
   const useSymbolFilter = options.symbolIds && options.symbolIds.length > 0;
 
@@ -209,8 +212,10 @@ export async function queryMemories(
       ? "ORDER BY confidence DESC"
       : "ORDER BY updatedAt DESC";
 
-  // Over-fetch with a generous LIMIT to bound DB work before JS-side tag filtering
-  const overFetchLimit = safeLimit * 5;
+  // Over-fetch enough rows to cover both the post-filter (tags) and the
+  // JS-side offset window. Deep pagination gets progressively more expensive;
+  // callers that need it should tighten filters instead of chasing large offsets.
+  const overFetchLimit = (safeOffset + safeLimit) * 5;
   params.overFetchLimit = overFetchLimit;
   const cypher = `${matchClause}
      ${whereClause}
@@ -228,7 +233,7 @@ export async function queryMemories(
     });
   }
 
-  return rows.slice(0, safeLimit).map(toMemoryRow);
+  return rows.slice(safeOffset, safeOffset + safeLimit).map(toMemoryRow);
 }
 
 export async function softDeleteMemory(

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -2189,6 +2189,7 @@ export const MemoryQueryRequestSchema = z.object({
   symbolIds: z.array(z.string()).max(100).optional(),
   staleOnly: z.boolean().optional(),
   limit: z.number().int().min(1).max(100).optional(),
+  offset: z.number().int().min(0).max(10000).optional(),
   sortBy: z.enum(["recency", "confidence"]).optional(),
 });
 
@@ -2197,6 +2198,9 @@ export const MemoryQueryResponseSchema = z.object({
   memories: z.array(SurfacedMemorySchema),
   total: z.number().int().min(0),
   hasMore: z.boolean().optional(),
+  // Continuation offset for the next page. Non-null when hasMore is true,
+  // null (or omitted) when the caller has reached the end of the result set.
+  nextOffset: z.number().int().min(0).nullable().optional(),
 });
 
 export const MemoryRemoveRequestSchema = z.object({

--- a/src/mcp/tools/info.ts
+++ b/src/mcp/tools/info.ts
@@ -1,9 +1,41 @@
+import { basename } from "path";
 import { z } from "zod";
 import { collectInfoReport, type InfoReport } from "../../info/report.js";
 
-export const InfoRequestSchema = z.object({}).passthrough();
+export const InfoRequestSchema = z
+  .object({
+    // When true, absolute filesystem paths in the response are replaced
+    // with just their basename. Set this in multi-tenant or HTTP-transport
+    // deployments so callers cannot learn the server's home directory,
+    // install location, or database layout from an info call.
+    redactPaths: z.boolean().optional(),
+  })
+  .passthrough();
+
+type InfoRequest = z.infer<typeof InfoRequestSchema>;
 
 /** Collects and returns the server info/diagnostics report. */
-export async function handleInfo(): Promise<InfoReport> {
-  return collectInfoReport();
+export async function handleInfo(args?: unknown): Promise<InfoReport> {
+  const request: InfoRequest =
+    args === undefined ? {} : InfoRequestSchema.parse(args);
+  const report = await collectInfoReport();
+  return request.redactPaths ? redactInfoPaths(report) : report;
+}
+
+function redactInfoPaths(report: InfoReport): InfoReport {
+  const redact = (p: string | null): string | null =>
+    p === null ? null : basename(p);
+  return {
+    ...report,
+    config: { ...report.config, path: basename(report.config.path) },
+    logging: { ...report.logging, path: redact(report.logging.path) },
+    ladybug: {
+      ...report.ladybug,
+      activePath: redact(report.ladybug.activePath),
+    },
+    native: {
+      ...report.native,
+      sourcePath: redact(report.native.sourcePath),
+    },
+  };
 }

--- a/src/mcp/tools/memory.ts
+++ b/src/mcp/tools/memory.ts
@@ -270,6 +270,7 @@ export async function handleMemoryQuery(
     symbolIds,
     staleOnly,
     limit = 10,
+    offset = 0,
     sortBy = "recency",
   } = request;
 
@@ -295,6 +296,7 @@ export async function handleMemoryQuery(
       symbolIds,
       staleOnly,
       limit,
+      offset,
       sortBy,
     });
   } catch (err) {
@@ -314,11 +316,16 @@ export async function handleMemoryQuery(
     tags: safeJsonParse(row.tagsJson, StringArraySchema, []),
   }));
 
+  const hasMore = memories.length === limit;
   return {
     repoId,
     memories,
     total: memories.length,
-    hasMore: memories.length === limit,
+    hasMore,
+    // Continuation offset for the next page, or null when there is no more.
+    // Previously hasMore was signaled but no cursor was provided, leaving
+    // callers unable to actually advance.
+    nextOffset: hasMore ? offset + limit : null,
   };
 }
 

--- a/tests/unit/info-redact-paths.test.ts
+++ b/tests/unit/info-redact-paths.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { basename } from "path";
+
+import { handleInfo } from "../../dist/mcp/tools/info.js";
+
+// ---------------------------------------------------------------------------
+// Regression guard for the info.ts path disclosure fix. Confirms that passing
+// { redactPaths: true } replaces the absolute paths that handleInfo normally
+// returns with their basenames, so HTTP-transport or multi-tenant deployments
+// can avoid leaking the server's filesystem layout.
+// ---------------------------------------------------------------------------
+
+describe("handleInfo path redaction", () => {
+  it("returns absolute paths by default (backward compatible)", async () => {
+    const report = await handleInfo();
+    // Should have at least a config.path string
+    assert.equal(typeof report.config.path, "string");
+    // Most deployments will have a config path that is either absolute or
+    // the default relative path; either way, the key must be present.
+    assert.ok("path" in report.config);
+  });
+
+  it("redacts absolute paths to basenames when redactPaths: true", async () => {
+    const full = await handleInfo();
+    const redacted = await handleInfo({ redactPaths: true });
+
+    // config.path is always present as a string. Basenames have no slashes
+    // and no Windows drive letters, and never contain a path separator that
+    // is not at the end of the string.
+    assert.equal(redacted.config.path, basename(full.config.path));
+    assert.equal(redacted.logging.path, full.logging.path === null ? null : basename(full.logging.path));
+    assert.equal(redacted.ladybug.activePath, full.ladybug.activePath === null ? null : basename(full.ladybug.activePath));
+    assert.equal(redacted.native.sourcePath, full.native.sourcePath === null ? null : basename(full.native.sourcePath));
+
+    // The basename should not contain path separators.
+    assert.ok(!redacted.config.path.includes("/"));
+    assert.ok(!redacted.config.path.includes("\\"));
+  });
+
+  it("leaves non-path fields untouched when redactPaths: true", async () => {
+    const full = await handleInfo();
+    const redacted = await handleInfo({ redactPaths: true });
+    assert.equal(redacted.version, full.version);
+    assert.equal(redacted.runtime.node, full.runtime.node);
+    assert.equal(redacted.runtime.platform, full.runtime.platform);
+    assert.equal(redacted.config.exists, full.config.exists);
+    assert.equal(redacted.ladybug.available, full.ladybug.available);
+  });
+});


### PR DESCRIPTION
Two API-shape fixes from the ongoing review of MCP tools.

- sdl.info absolute path disclosure (#12): handleInfo returned `config.path`, `logging.path`, `ladybug.activePath`, and `native.sourcePath` as absolute filesystem paths. On a shared server or with HTTP transport, that leaks the server's home directory, install location, and DB layout to any caller with access to the info tool. Extend InfoRequestSchema with an optional `redactPaths` flag that replaces each path with just its basename. The default is still absolute paths so existing stdio-transport tooling is unchanged; operators exposing SDL-MCP in multi-tenant or HTTP deployments can pass `{ redactPaths: true }`. Adds tests/unit/info-redact-paths.test.ts covering the backward-compatible default and the redacted shape.

- sdl.memory.query hasMore without a cursor (#13): the response set `hasMore: true` when `memories.length === limit`, but there was no way for the caller to advance — they would either loop on the same page forever or give up. Add an optional `offset` field to MemoryQueryRequestSchema (int, 0..10000) and echo a matching `nextOffset` in the response (or null at the tail). Plumb the offset through `queryMemories` in src/db/ladybug-memory.ts, including widening the over-fetch bound to `(offset + limit) * 5` so the JS-side tag post-filter still has enough rows to work with. Deep pagination gets progressively more expensive — that's documented — but small offsets (the common case) cost essentially nothing.

Typecheck clean; info-report / ladybug-memory-queries / memory-tools / memory-tools-gating / info-redact-paths suites all pass (53 + 3 targeted).