### PR TITLE
Stabilize nightly benchmark matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,6 +604,13 @@ jobs:
           "
 
       - name: Run full benchmark matrix
+        shell: bash
+        env:
+          # Keep benchmark matrix claim validation on the stable JS/LadybugDB path.
+          # Native parser crash coverage lives in native-build and sync-memory.
+          SDL_MCP_DISABLE_NATIVE_ADDON: "1"
+          # Serialize pass-1 DB writes against parser work to avoid hosted-runner exit 139 flakes.
+          SDL_MCP_PASS1_STABLE_DB_WRITES: "1"
         run: npm run benchmark:matrix -- --matrix benchmarks/real-world/matrix.json --config benchmarks/real-world/benchmark.config.json --out-dir .benchmark/matrix-nightly
 
       - name: Audit realism benchmark claims (non-blocking)
@@ -620,10 +627,12 @@ jobs:
           echo "- Realism claim validation is audit-only on the scheduled workflow until the benchmark matrix is retuned to satisfy the published claim floors again." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload matrix artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-matrix-nightly
           path: .benchmark/matrix-nightly/**
+          if-no-files-found: warn
           retention-days: 14
 
   sync-memory:

--- a/tests/unit/release-regressions.test.ts
+++ b/tests/unit/release-regressions.test.ts
@@ -87,6 +87,9 @@ describe("release regression guards", () => {
     const nativeBuildJob =
       ciSource.match(/native-build:\s*[\s\S]*?\n  benchmark-matrix-nightly:/)
         ?.[0] ?? "";
+    const benchmarkMatrixNightlyJob =
+      ciSource.match(/benchmark-matrix-nightly:\s*[\s\S]*?\n  sync-memory:/)
+        ?.[0] ?? "";
     const syncMemoryJob =
       ciSource.match(/sync-memory:\s*[\s\S]*?\n  sync-validation:/)?.[0] ?? "";
 
@@ -98,6 +101,10 @@ describe("release regression guards", () => {
     assert.ok(
       nativeBuildJob,
       "native-build job section should be present in ci workflow",
+    );
+    assert.ok(
+      benchmarkMatrixNightlyJob,
+      "benchmark-matrix-nightly job section should be present in ci workflow",
     );
     assert.ok(
       syncMemoryJob,
@@ -179,6 +186,18 @@ describe("release regression guards", () => {
       benchmarksJob,
       /SDL_MCP_PASS1_STABLE_DB_WRITES:\s*"1"/,
       "benchmark CI should serialize pass-1 DB writes against parser work to avoid hosted-runner exit 139 flakes",
+    );
+
+    assert.match(
+      benchmarkMatrixNightlyJob,
+      /name:\s*Run full benchmark matrix[\s\S]*SDL_MCP_DISABLE_NATIVE_ADDON:\s*"1"[\s\S]*SDL_MCP_PASS1_STABLE_DB_WRITES:\s*"1"[\s\S]*npm run benchmark:matrix/s,
+      "nightly benchmark matrix should use the same stable non-native benchmark path as benchmark CI",
+    );
+
+    assert.match(
+      benchmarkMatrixNightlyJob,
+      /name:\s*Upload matrix artifacts[\s\S]*if:\s*always\(\)[\s\S]*uses:\s*actions\/upload-artifact@v7[\s\S]*if-no-files-found:\s*warn/s,
+      "nightly benchmark matrix should upload partial artifacts even when matrix execution fails",
     );
 
     assert.match(


### PR DESCRIPTION
## Summary
- run the scheduled benchmark matrix on the same stable non-native benchmark path as benchmark CI
- keep pass-1 DB writes serialized during the full matrix to avoid hosted-runner exit 139 flakes
- upload partial matrix artifacts even when matrix execution fails
- add release-regression guards for the nightly matrix isolation and artifact upload behavior

## Verification
- source-level red check confirmed `main` lacked the nightly stabilization env and always-upload artifact guard
- source-level green check confirmed the branch workflow matches the new regression expectations

Note: local repo shell commands are blocked by SDL-MCP enforcement in this session, so full test execution is delegated to GitHub CI on this PR.