### PR TITLE
Fix Windows OpenSSL build hash helper in CI

### DIFF
--- a/scripts/build-ladybug-openssl-runtime.ps1
+++ b/scripts/build-ladybug-openssl-runtime.ps1
@@ -19,7 +19,19 @@ $installDir = Join-Path $tempRoot "install"
 $binDir = Join-Path $packageRoot "bin"
 
 function Get-Sha256([string]$Path) {
-  (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+  $sha256 = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+      $hash = $sha256.ComputeHash($stream)
+    } finally {
+      $stream.Dispose()
+    }
+  } finally {
+    $sha256.Dispose()
+  }
+
+  -join ($hash | ForEach-Object { $_.ToString("x2") })
 }
 
 function Find-FirstExisting([string[]]$Candidates) {


### PR DESCRIPTION
Fixes the trusted-publish workflow failure in run 29369860318.

The Windows build runner reported `Get-FileHash` was unavailable inside `scripts/build-ladybug-openssl-runtime.ps1`. This replaces the script helper with .NET SHA-256 so the build does not depend on that cmdlet.

Verification:
- Function-only PowerShell check returned `sha256_ok=<64 hex chars>`.
- `git diff --check` passed for the script.