### PR TITLE
ci(windows): allow OpenSSL test suite to finish

### DIFF
--- a/scripts/build-ladybug-openssl-runtime.ps1
+++ b/scripts/build-ladybug-openssl-runtime.ps1
@@ -206,7 +206,7 @@ try {
   if (-not $sourceDir) { throw "OpenSSL source directory missing after extraction under: $tempRoot" }
   Run-Logged $perl @("Configure", $source.configureTarget, "shared", "--release", "--prefix=$installDir", "--openssldir=$installDir\ssl") $sourceDir
   Run-Logged $nmake @() $sourceDir
-  Run-Logged $nmake @("test") $sourceDir
+  Run-Logged $nmake @("test") $sourceDir 3600
   Run-Logged $nmake @("install_sw") $sourceDir
 
   Remove-Item -LiteralPath (Join-Path $binDir "*.dll") -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
The runtime publish workflow reached `nmake test` and timed out after 1200 seconds while OpenSSL tests were still passing. This only gives the test command a longer 3600s timeout; configure/build/install keep the existing 1200s bound.

Verification:
- `git diff --check`
- PowerShell parser check for `scripts/build-ladybug-openssl-runtime.ps1`