### PR TITLE
ci(windows): keep OpenSSL package text LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
+/.gitattributes text eol=lf
+
 # Git LFS tracking for large model files
 models/**/*.onnx filter=lfs diff=lfs merge=lfs -text
+
+# Keep audited runtime-package text artifacts byte-stable across Windows checkouts.
+ladybug-openssl/npm/win32-x64/*.json text eol=lf
+ladybug-openssl/npm/win32-x64/*.md text eol=lf
+ladybug-openssl/npm/win32-x64/*.txt text eol=lf


### PR DESCRIPTION
## Summary
- force LF checkout for the audited OpenSSL runtime npm package text files
- keep `.gitattributes` itself LF-normalized

## Verification
- `git check-attr text eol -- .gitattributes ladybug-openssl/npm/win32-x64/OPENSSL-LICENSE.txt ladybug-openssl/npm/win32-x64/README.md ladybug-openssl/npm/win32-x64/package.json ladybug-openssl/npm/win32-x64/sbom.spdx.json`
- `git diff --check`
- `node --experimental-strip-types --test tests/integration/ladybug-openssl-package-contract.test.ts` (6/6 pass)
- fresh local clone with `core.autocrlf=true`: `OPENSSL-LICENSE.txt` hash remained `7d5450cb2d142651b8afa315b5f238efc805dad827d91ba367d8516bc9d49e7a`, `crlfCount=0`

Note: local `npm run ladybug:openssl:verify` reached an unrelated dependency-state gate because this worktree has no installed `@ladybugdb/core@0.18.1`; the targeted package contract and checkout behavior are verified above.