### PR TITLE
ci(release): preflight OpenSSL npm scope

### DIFF
--- a/.github/workflows/publish-ladybug-openssl.yml
+++ b/.github/workflows/publish-ladybug-openssl.yml
@@ -37,6 +37,19 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
+      - name: Preflight npm publish scope
+        if: ${{ inputs.dry_run == false }}
+        shell: pwsh
+        run: |
+          $whoami = npm whoami
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Write-Host "npm authenticated as $whoami"
+          $scopePackages = npm access list packages @sdl-mcp --json
+          if ($LASTEXITCODE -ne 0) {
+            throw "npm scope @sdl-mcp is not visible to this token; create the scope or grant publish access before running the OpenSSL build."
+          }
+          $scopePackages | ConvertFrom-Json | Out-Null
+
       - name: Install NASM and Strawberry Perl
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- add a real-publish preflight before Chocolatey/OpenSSL work
- fail early when the `@sdl-mcp` npm scope is not visible to the publish token

## Why
Publish run https://github.com/GlitterKill/sdl-mcp/actions/runs/29383829510 successfully built, verified, packed, and uploaded the OpenSSL runtime artifact, then failed at `npm publish` because npm returned `E404 Scope not found` for `@sdl-mcp/ladybug-openssl-win32-x64`.

This avoids burning another ~45-minute Windows OpenSSL build when npm scope setup is missing.

## Verification
- `git diff --check`
- local execution of the added PowerShell preflight: authenticated as `glitterkill`, then failed immediately with `Scope not found` and the new explicit message.