### PR TITLE
ci(release): use trusted publishing without npm token preflight

### DIFF
--- a/.github/workflows/publish-ladybug-openssl.yml
+++ b/.github/workflows/publish-ladybug-openssl.yml
@@ -37,19 +37,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
-      - name: Preflight npm publish scope
-        if: ${{ inputs.dry_run == false }}
-        shell: pwsh
-        run: |
-          $whoami = npm whoami
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          Write-Host "npm authenticated as $whoami"
-          $scopePackages = npm access list packages @sdl-mcp --json
-          if ($LASTEXITCODE -ne 0) {
-            throw "npm scope @sdl-mcp is not visible to this token; create the scope or grant publish access before running the OpenSSL build."
-          }
-          $scopePackages | ConvertFrom-Json | Out-Null
-
       - name: Install NASM and Strawberry Perl
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- remove the blocking npm token preflight from the OpenSSL runtime publish workflow

## Why
After creating the `sdl-mcp` npm org, local npm access is valid:
- `npm whoami` -> `glitterkill`
- `npm org ls sdl-mcp --json` -> `glitterkill: owner`
- `npm access list packages @sdl-mcp --json` -> `{}`

The GitHub Actions workflow uses npm trusted publishing/OIDC. The token-based preflight fails in CI with `E401 Unauthorized - GET /-/whoami` before trusted publishing can run, so it blocks the correct publish path.

## Verification
- `git diff --check`
- local npm org/access commands above