### PR TITLE
ci(db): pass npm token to OpenSSL runtime publish

### DIFF
--- a/.github/workflows/publish-ladybug-openssl.yml
+++ b/.github/workflows/publish-ladybug-openssl.yml
@@ -139,6 +139,8 @@ jobs:
       - name: Publish runtime package
         if: ${{ inputs.dry_run == false }}
         working-directory: ${{ env.PACKAGE_DIR }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public --tag latest
 
       - name: Verify registry tarball and provenance

--- a/.github/workflows/publish-ladybug-openssl.yml
+++ b/.github/workflows/publish-ladybug-openssl.yml
@@ -148,9 +148,23 @@ jobs:
         shell: pwsh
         run: |
           $spec = "$env:PACKAGE_NAME@$env:PACKAGE_VERSION"
-          $metadata = npm view $spec --json | ConvertFrom-Json
-          if ($metadata.name -ne $env:PACKAGE_NAME -or $metadata.version -ne $env:PACKAGE_VERSION) {
-            throw "Registry metadata mismatch for $spec"
+          $metadata = $null
+          for ($attempt = 1; $attempt -le 30; $attempt++) {
+            $metadataJson = npm view $spec --json 2>$null
+            if ($LASTEXITCODE -eq 0) {
+              $candidate = $metadataJson | ConvertFrom-Json
+              if ($candidate.name -eq $env:PACKAGE_NAME -and $candidate.version -eq $env:PACKAGE_VERSION) {
+                $metadata = $candidate
+                break
+              }
+            }
+
+            if ($attempt -eq 30) {
+              throw "Registry metadata mismatch for $spec after $attempt attempts"
+            }
+
+            Write-Host "Registry metadata for $spec is not visible yet; retrying in 20 seconds (attempt $attempt/30)."
+            Start-Sleep -Seconds 20
           }
           $packJson = npm pack $spec --json
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/ladybug-openssl/npm/win32-x64/package.json
+++ b/ladybug-openssl/npm/win32-x64/package.json
@@ -3,6 +3,10 @@
   "version": "3.5.7-sdl.1",
   "description": "SDL-MCP temporary OpenSSL runtime for LadybugDB FTS on Windows x64",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GlitterKill/sdl-mcp"
+  },
   "os": [
     "win32"
   ],

--- a/scripts/build-ladybug-openssl-runtime.ps1
+++ b/scripts/build-ladybug-openssl-runtime.ps1
@@ -205,7 +205,9 @@ try {
   }
   if (-not $sourceDir) { throw "OpenSSL source directory missing after extraction under: $tempRoot" }
   Run-Logged $perl @("Configure", $source.configureTarget, "shared", "--release", "--prefix=$installDir", "--openssldir=$installDir\ssl") $sourceDir
-  Run-Logged $nmake @() $sourceDir
+  # The default OpenSSL Windows target also compiles test binaries; hosted
+  # runners can exceed the generic short-command timeout before tests start.
+  Run-Logged $nmake @() $sourceDir 3600
   Run-Logged $nmake @("test") $sourceDir 3600
   Run-Logged $nmake @("install_sw") $sourceDir
 

--- a/tests/integration/ladybug-openssl-package-contract.test.ts
+++ b/tests/integration/ladybug-openssl-package-contract.test.ts
@@ -87,6 +87,10 @@ it("defines the data-only Windows x64 npm package contract", () => {
   assert.equal(packageJson.version, source.packageVersion);
   assert.equal(packageJson.description, "SDL-MCP temporary OpenSSL runtime for LadybugDB FTS on Windows x64");
   assert.equal(packageJson.license, "Apache-2.0");
+  assert.deepEqual(packageJson.repository, {
+    type: "git",
+    url: "https://github.com/GlitterKill/sdl-mcp",
+  });
   assert.deepEqual(packageJson.os, ["win32"]);
   assert.deepEqual(packageJson.cpu, ["x64"]);
   assert.deepEqual(packageJson.files, [


### PR DESCRIPTION
## Summary
- pass NPM_TOKEN to the scoped OpenSSL runtime npm publish step
- keep provenance/id-token publishing unchanged

## Verification
- git diff --check -- .github/workflows/publish-ladybug-openssl.yml
- Failed runtime publish run 29386392892 reached the publish step and returned npm E404 on PUT after successful build/package/provenance generation